### PR TITLE
Adds repeating standings rank to leaderboard 

### DIFF
--- a/js/components/Table/Row.js
+++ b/js/components/Table/Row.js
@@ -11,7 +11,7 @@ class Row extends React.Component {
   createRow(data) {
     const row = [
       {
-        title: data.user.data.first_name,
+        title: data.rank.toString().concat('. ', data.user.data.first_name),
       },
       {
         title: data.quantity === null ? 0 : data.quantity,

--- a/js/components/Table/index.js
+++ b/js/components/Table/index.js
@@ -5,10 +5,42 @@ import Row from './Row';
 import './table.scss';
 
 class Table extends React.Component {
+  constructor() {
+    super();
+
+    this.addRankToUsers = this.addRankToUsers.bind(this);
+  }
+
+  addRankToUsers(data) {
+    let increment = 1;
+    let rank = 1;
+    const lastElement = data[data.length - 1];
+
+    data.forEach(function(element, index) {
+      // Don't perform this logic on the first element
+      if (index > 0) {
+        // If the last row quantity equals this rows quantity, just increment.
+        if (element['quantity'] === lastElement['quantity']) {
+          increment++;
+        // Otherwise apply the increment to the rank and reset it back to 1.
+        } else {
+          rank += increment;
+          increment = 1;
+        }
+      }
+
+      // Give each row a rank.
+      element['rank'] = rank;
+    });
+
+    return data;
+  }
+
   render() {
     const heading = this.props.headings.map((title, index) => <th key={index} className="table__cell"><h3 className="heading -delta">{title}</h3></th>);
+    const users = this.addRankToUsers(this.props.data);
 
-    const rows = this.props.data.map((content, index) => {
+    const rows = users.map((content, index) => {
       return <Row key={index} data={content} />;
     });
 

--- a/js/components/Table/index.js
+++ b/js/components/Table/index.js
@@ -8,21 +8,19 @@ class Table extends React.Component {
   constructor() {
     super();
 
-    this.addRankToUsers = this.addRankToUsers.bind(this);
+    this.addRepeatedStandingsRankToUsers = this.addRepeatedStandingsRankToUsers.bind(this);
   }
 
-  addRankToUsers(data) {
+  addRepeatedStandingsRankToUsers(data) {
     let increment = 1;
     let rank = 1;
-    const lastElement = data[data.length - 1];
 
     data.forEach(function(element, index) {
       // Don't perform this logic on the first element
       if (index > 0) {
-        // If the last row quantity equals this rows quantity, just increment.
-        if (element['quantity'] === lastElement['quantity']) {
-          increment++;
-        // Otherwise apply the increment to the rank and reset it back to 1.
+        // Apply "repeated standings" rank and reset it back to 1.
+        if (element['quantity'] === data[index - 1]['quantity']) {
+          rank = data[index - 1]['rank']
         } else {
           rank += increment;
           increment = 1;
@@ -38,7 +36,7 @@ class Table extends React.Component {
 
   render() {
     const heading = this.props.headings.map((title, index) => <th key={index} className="table__cell"><h3 className="heading -delta">{title}</h3></th>);
-    const users = this.addRankToUsers(this.props.data);
+    const users = this.addRepeatedStandingsRankToUsers(this.props.data);
 
     const rows = users.map((content, index) => {
       return <Row key={index} data={content} />;


### PR DESCRIPTION
This PR adds repeat standing rankings to the leaderboard (if multiple users have same # of empties collected, they are same rank). 

Here is the unstyled look:
![screen shot 2018-02-14 at 11 07 02 am](https://user-images.githubusercontent.com/9019452/36214518-abc6e576-1177-11e8-9668-8156b818b9db.png)

And a screen shot of the bottom with users who have collected 0:
![screen shot 2018-02-14 at 11 07 12 am](https://user-images.githubusercontent.com/9019452/36214520-abdee306-1177-11e8-84fe-ca9355068338.png)

