### PR TITLE
Add college logos in own column

### DIFF
--- a/js/components/Table/Row.js
+++ b/js/components/Table/Row.js
@@ -12,12 +12,13 @@ class Row extends React.Component {
 
   render() {
     const image = this.getImage(this.props.data);
+    const rank = this.props.data.rank.toString().concat('.');
     const firstName = this.props.data.user.data.first_name;
     const quantity = this.props.data.quantity;
 
     return (
       <tr className="table__row">
-        <td className="table__cell"><img src={image}/>{firstName}</td>
+        <td className="table__cell">{rank}<img src={image}/>{firstName}</td>
         <td className="table__cell">{quantity || 0}</td>
       </tr>
     );

--- a/js/components/Table/Row.js
+++ b/js/components/Table/Row.js
@@ -21,11 +21,17 @@ class Row extends React.Component {
     return row;
   }
 
+  getImage(data) {
+    return 'images/college_logos/' + data.northstar_id +'.png';
+  }
+
   render() {
     const content = this.createRow(this.props.data);
+    const image = this.getImage(this.props.data);
 
     return (
       <tr className="table__row">
+        <td className="table__cell"><img src={image}/></td>
         {content.map((cell, index) => <td className="table__cell" key={index}>{cell.title}</td>)}
       </tr>
     );

--- a/js/components/Table/Row.js
+++ b/js/components/Table/Row.js
@@ -4,21 +4,6 @@ import { map } from 'lodash';
 class Row extends React.Component {
   constructor() {
     super();
-
-    this.createRow = this.createRow.bind(this);
-  }
-
-  createRow(data) {
-    const row = [
-      {
-        title: data.rank.toString().concat('. ', data.user.data.first_name),
-      },
-      {
-        title: data.quantity === null ? 0 : data.quantity,
-      },
-    ];
-
-    return row;
   }
 
   getImage(data) {
@@ -26,13 +11,14 @@ class Row extends React.Component {
   }
 
   render() {
-    const content = this.createRow(this.props.data);
     const image = this.getImage(this.props.data);
+    const firstName = this.props.data.user.data.first_name;
+    const quantity = this.props.data.quantity;
 
     return (
       <tr className="table__row">
-        <td className="table__cell"><img src={image}/></td>
-        {content.map((cell, index) => <td className="table__cell" key={index}>{cell.title}</td>)}
+        <td className="table__cell"><img src={image}/>{firstName}</td>
+        <td className="table__cell">{quantity || 0}</td>
       </tr>
     );
   }


### PR DESCRIPTION
I tried for a long time to get these images into the columns with the names, but I couldn't figure out how to get it to render properly! The idea that we had floated around was naming the images by the Northstar ID so we didn't have to do any kind of matching and could just grab the image directly.

I landed on putting the images in their own column to the left of the names. Currently is unstyled and looks like this:

![image](https://user-images.githubusercontent.com/4240292/36560592-2759490a-17df-11e8-89f9-bd5a6ef5b632.png)


**Future Use**
Upload college logos to `image/college_logos` as `{northstar_id}.png`. Until we have the images set up, broken images will show on the page.