### PR TITLE
Update domain in deploy step

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -12,4 +12,5 @@ deploy:
   steps:
     - lukevivier/gh-pages:
         token: $GH_TOKEN
+        domain: competitions.dosomething.org
         basedir: site


### PR DESCRIPTION
#### What's this PR do?

Adds `competitions.dosomething.org` as the domain in the wercker deploy step so we don't have to manually set it after every deploy. 

#### How should this be reviewed?

👀 

and after a deploy you should be able to see the site as `http://competitions.dosomething.org`

#### Any background context you want to provide?
what else?

#### Relevant tickets

🐛 

