### PR TITLE
Use the accepted quantity we get from Rogue, and sort by that too

### DIFF
--- a/js/components/Leaderboard/index.js
+++ b/js/components/Leaderboard/index.js
@@ -22,7 +22,7 @@ class Leaderboard extends React.Component {
 				campaign_id: '7536',
 			},
 			orderBy: 'quantity,desc',
-			include: 'user',
+			include: 'accepted_quantity,user',
 			// @TODO: remove this limit when we go live since
 			// there will only be 50 users in real competition.
 			// This is just as a placeholder to see data.

--- a/js/components/Table/Row.js
+++ b/js/components/Table/Row.js
@@ -23,7 +23,7 @@ class Row extends React.Component {
     const rank = this.props.data.rank.toString().concat('.');
     const firstName = this.props.data.user.data.first_name;
     const collegeName = this.getCollegeName(this.props.data.northstar_id);
-    const quantity = this.props.data.quantity;
+    const quantity = this.props.data.accepted_quantity.data.quantity;
 
     return (
       <tr className="table__row">

--- a/js/components/Table/index.js
+++ b/js/components/Table/index.js
@@ -9,6 +9,13 @@ class Table extends React.Component {
     super();
 
     this.addRepeatedStandingsRankToUsers = this.addRepeatedStandingsRankToUsers.bind(this);
+    this.sortByAcceptedQuantity = this.sortByAcceptedQuantity.bind(this);
+  }
+
+  sortByAcceptedQuantity(data) {
+    const sortedData = data.sort((a,b) => b.accepted_quantity.data.quantity - a.accepted_quantity.data.quantity);
+
+    return sortedData;
   }
 
   addRepeatedStandingsRankToUsers(data) {
@@ -19,7 +26,7 @@ class Table extends React.Component {
       // Don't perform this logic on the first element
       if (index > 0) {
         // Apply "repeated standings" rank and reset it back to 1.
-        if (element['quantity'] === data[index - 1]['quantity']) {
+        if (element['accepted_quantity']['data']['quantity'] === data[index - 1]['accepted_quantity']['data']['quantity']) {
           rank = data[index - 1]['rank']
         } else {
           rank += increment;
@@ -36,7 +43,8 @@ class Table extends React.Component {
 
   render() {
     const heading = this.props.headings.map((title, index) => <th key={index} className="table__cell"><h3 className="heading -delta">{title}</h3></th>);
-    const users = this.addRepeatedStandingsRankToUsers(this.props.data);
+    const sortedData = this.sortByAcceptedQuantity(this.props.data);
+    const users = this.addRepeatedStandingsRankToUsers(sortedData);
 
     const rows = users.map((content, index) => {
       return <Row key={index} data={content} />;


### PR DESCRIPTION
**Don't merge until https://github.com/DoSomething/rogue/pull/646 is live on production.**

#### What's this PR do?
- Ask Rogue to include `accepted_quantity`
- Sort the signups we get based on `accepted_quantity` and use the sorted result
- Use `accepted_quantity` anywhere that we were using `quantity`

#### How should this be reviewed?
Does this ensure that folks are displayed properly based on their accepted quantity?

#### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/156024795)

#### Checklist
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.