### PR TITLE
Loading symbol on Leaderboard, no period with rank

### DIFF
--- a/js/components/Leaderboard/index.js
+++ b/js/components/Leaderboard/index.js
@@ -9,7 +9,8 @@ class Leaderboard extends React.Component {
 		super();
 
 		this.state = {
-			jsonReturnedValue: []
+			jsonReturnedValue: [],
+      loading: true,
 		}
 
 		this.api = new RestApiClient('https://rogue.dosomething.org/');
@@ -29,14 +30,14 @@ class Leaderboard extends React.Component {
 			limit: '50',
 		})
 	      .then((json) => {
-	        this.setState({ jsonReturnedValue: json['data'] });
+	        this.setState({ jsonReturnedValue: json['data'], loading: false });
 	    });
 	}
 
 	render() {
 		return (
 			<div className="table-responsive container__block">
-				<Table className="table" headings={['Rank', 'Name', '# of Empties']} data={this.state.jsonReturnedValue} />
+				<Table className="table" headings={['Rank', 'Name', '# of Empties']} data={this.state.jsonReturnedValue} loading={this.state.loading} />
 			</div>
 		);
 	}

--- a/js/components/Leaderboard/index.js
+++ b/js/components/Leaderboard/index.js
@@ -36,7 +36,7 @@ class Leaderboard extends React.Component {
 
 	render() {
 		return (
-			<div className="table-responsive container__block">
+			<div className="table-responsive">
 				<Table className="table" headings={['Rank', 'Name', '# of Empties']} data={this.state.jsonReturnedValue} loading={this.state.loading} />
 			</div>
 		);

--- a/js/components/Table/Row.js
+++ b/js/components/Table/Row.js
@@ -20,7 +20,7 @@ class Row extends React.Component {
 
   render() {
     const image = this.getImage(this.props.data.northstar_id);
-    const rank = this.props.data.rank.toString().concat('.');
+    const rank = this.props.data.rank;
     const firstName = this.props.data.user.data.first_name;
     const collegeName = this.getCollegeName(this.props.data.northstar_id);
     const quantity = this.props.data.quantity;

--- a/js/components/Table/index.js
+++ b/js/components/Table/index.js
@@ -38,6 +38,19 @@ class Table extends React.Component {
     const heading = this.props.headings.map((title, index) => <th key={index} className="table__cell"><h3 className="heading -delta">{title}</h3></th>);
     const users = this.addRepeatedStandingsRankToUsers(this.props.data);
 
+    if(this.props.loading) {
+      return (
+        <table className="table">
+          <thead>
+            <th colspan="3" className="table__title">Leaderboard</th>
+            <tr className="table__header">
+                <div className="spinner" />
+            </tr>
+          </thead>
+        </table>
+      );
+    }
+
     const rows = users.map((content, index) => {
       return <Row key={index} data={content} />;
     });

--- a/sass/app.scss
+++ b/sass/app.scss
@@ -34,6 +34,27 @@ $forge-path: "~@dosomething/forge/assets/";
   }
 }
 
+.leaderboard {
+  /*The include media statements just wrap these styles in media queries.
+  For anything less than medium these should probably just stack*/
+  @include media($medium) {
+    float: left;
+    width: 50%;
+  }
+}
+
+.sidebar {
+  @include media($medium) {
+    /*Forgot that when using sticky, we can still float. Typically specifying positioning
+    like absolute, you should not also use float, since it ignores floats, but not in the case
+    of position sticky!*/
+    float: right;
+    position: sticky;
+    top: 24px;
+    width: 50%;
+  }
+}
+
 .competition_title_block {
   background-color: #222;
   text-align: center;

--- a/site/index.html
+++ b/site/index.html
@@ -39,20 +39,16 @@
         <p>Let’s Do This! Check back every Monday to see where you stack up! Head <a href="https://www.dosomething.org/us/campaigns/rinse-recycle-repeat-college-competition" target="_blank">here</a> to add to your impact and climb the leaderboard!</p>
       </div>
 
-      <ul class="gallery -duo">
-        <li>
-          <div class="figure__media">
-            <div id="leaderboard"></div>
-          </div>
-        </li>
+      <div class="container">
+        <div class="wrapper">
 
-        <li>
-          <div class="figure__media">
+          <div id="leaderboard" class="leaderboard container__block"></div>
+
+          <div class="sidebar container__block">
             <div class="card">
               <header class="card__title">
                   <h1>FAQ</h1>
               </header>
-
               <div class="card__content">
                 <h4>When does the leaderboard update?</h4>
                 <p>Every Monday afernoon! Which means if you want your numbers to be counted every week you need to submit your weekly update <a href="https://www.dosomething.org/us/campaigns/rinse-recycle-repeat-college-competition" target="_blank">here</a> by Sunday night.</p>
@@ -65,8 +61,10 @@
               </div>
             </div>
           </div>
-        </li>
-      </ul>
+
+        </div>
+      </div>
+
     </div>
   </div>
 


### PR DESCRIPTION
#### What's this PR do?
- Adds a loading symbol while Domino is getting the leaderboard data from Rogue
- Removes the period from the ranking in the Leaderboard
![leaderboard-load](https://user-images.githubusercontent.com/4240292/37852121-c65ae010-2eb7-11e8-9c96-81c6a521c22d.gif)

- Makes the FAQ sticky so that it is always visible
cc: special thanks to @weerd for helping with this puzzle and figuring out the solution DURING the sign-making party!
![sticky-faq](https://user-images.githubusercontent.com/4240292/38041745-8bff4e70-3280-11e8-9ac3-1220b728ff2a.gif)

#### How should this be reviewed?
Does it look right in the gifs?

#### Any background context you want to provide?
Pushing this up because these 2 pieces are done and I'm out on Monday. Wednesday update: got approval but no merge yet so I'm adding the final piece of the puzzle to this PR!

#### Relevant tickets
[Card](https://www.pivotaltracker.com/story/show/156024106)

#### Checklist
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.