### PR TITLE
override an inherited max-width setting

### DIFF
--- a/sass/app.scss
+++ b/sass/app.scss
@@ -142,3 +142,9 @@ $forge-path: "~@dosomething/forge/assets/";
     }
   }
 }
+
+.table__cell {
+  img {
+    max-width: unset;
+  }
+}


### PR DESCRIPTION
#### What's this PR do?

Fixes the sizing on logos displaying in the leaderboard table.This is a quick little hack to make sure there are no inherited css causing sizing issues. 

Bad logos: 
![image](https://user-images.githubusercontent.com/1700409/38210106-62fb0818-3684-11e8-8a03-bf4a474869dd.png)

Fixed logos: 
![image](https://user-images.githubusercontent.com/1700409/38210065-41308618-3684-11e8-827d-e05d4a7d4418.png)


