### PR TITLE
removes campaign_run_id from api call to Rogue

### DIFF
--- a/js/components/Leaderboard/index.js
+++ b/js/components/Leaderboard/index.js
@@ -21,9 +21,6 @@ class Leaderboard extends React.Component {
 			filter: {
 				campaign_id: '7536',
 			},
-      filter: {
-        campaign_run_id: '8066',
-      },
 			orderBy: 'quantity,desc',
 			include: 'accepted_quantity,user',
       // 50 users in the competition


### PR DESCRIPTION
#### What's this PR do?
removes `campaign_run_id` filter from api call to Rogue to `/api/v2/signups`

#### How should this be reviewed?
👀 

#### Relevant tickets
[Card](https://www.pivotaltracker.com/n/projects/2019429/stories/163460749)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.