### PR TITLE
updates to hit activity.dosomething.org instead of rogue.dosomething.org

### DIFF
--- a/js/components/Leaderboard/index.js
+++ b/js/components/Leaderboard/index.js
@@ -13,7 +13,7 @@ class Leaderboard extends React.Component {
       loading: true,
 		}
 
-		this.api = new RestApiClient('https://rogue.dosomething.org/');
+		this.api = new RestApiClient('https://activity.dosomething.org/');
 	}
 
 	componentDidMount() {


### PR DESCRIPTION
#### What's this PR do?
updates API call to hit activity.dosomething.org instead of rogue.dosomething.org

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
Hits `rogue.dosomething.org`, and the 302 response doesn't have CORS enabled.

#### Relevant tickets
#21 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.